### PR TITLE
WIP! Attempt at changing plugin loading structure

### DIFF
--- a/Humdrum.scm
+++ b/Humdrum.scm
@@ -33,7 +33,7 @@
 
 ;% TODO ties, slurs, grace notes
 
-(define-module (lilypond-export Humdrum))
+;(define-module (lilypond-export Humdrum))
 
 (use-modules
  (oll-core tree)
@@ -44,7 +44,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; humdrum export
 
-(define-public (exportHumdrum musicexport filename . options)
+(define-public (export-lilypond musicexport filename . options)
   ;(display musicexport)
   (let ((grid (tree-create 'grid))
         (bar-list (sort (filter integer? (tree-get-keys musicexport '())) (lambda (a b) (< a b))) )
@@ -269,5 +269,5 @@
         ))
     ))
 
-(set-object-property! exportHumdrum 'file-suffix "krn")
+(set-object-property! export-lilypond 'file-suffix "krn")
 

--- a/export-example.ly
+++ b/export-example.ly
@@ -52,14 +52,14 @@ music = \new PianoStaff <<
 >>
 
 % exporter can run without actually typesetting
-\exportMusic \default hum \music
+\exportMusic #'Humdrum \music
 
-opts.exporter = #exportMusicXML
+%opts.exporter = #exportMusicXML
 % or as a layout extension that is added to the layout
-\score {
-  \music
-  \layout {
-    \FileExport #opts
-  }
-  \midi {}
-}
+%\score {
+%  \music
+%  \layout {
+%    \FileExport #opts
+%  }
+%  \midi {}
+%}

--- a/package.ily
+++ b/package.ily
@@ -36,21 +36,21 @@
 
 %%%% export music
 % filebase: file basename - suffix (.krn/.xml) is taken from the exporter
-% exporter: symbol or function: hum -> humdrum, xml -> musicXML,
-%           not implemented yet: [l]mei -> [L-]MEI, lily -> LilyPond
+% target:   export module name (symbol?):
+%           - Humdrum,
+%           - MusicXML,
+%           to be implemented:
+%           - MEI
+%           - LilyPond
 %           or an exporter function #(lambda (export-tree filename . options) ...)
 % music: the music to export
 #(define (symbol-or-procedure? v) (or (symbol? v)(procedure? v)))
+
 exportMusic =
-#(let
-  ((exporters
-    `((xml . ,exportMusicXML)
-      (hum . ,exportHumdrum)
-      (lily . ,exportLilyPond))))
-  (define-void-function (filebase exporter music)
-    ((string? (ly:parser-output-name)) symbol-or-procedure? ly:music?)
-    (if (symbol? exporter)
-        (set! exporter (ly:assoc-get exporter exporters exportMusicXML #t)))
-    (ly:run-translator
-     (ly:score-music (scorify-music music))
-     (FileExport `((filebase . ,filebase)(exporter . ,exporter))))))
+#(define-void-function (filebase target music)
+   ((string? (ly:parser-output-name)) symbol-or-procedure? ly:music?)
+   (ly:run-translator
+    (ly:score-music (scorify-music music))
+    (FileExport
+     `((filebase . ,filebase)
+       (target . ,target)))))


### PR DESCRIPTION
This doesn't work yet, but I want to submit it for review.

The idea is to create better modularity for the various exporter modules (see discussion at https://github.com/openlilylib/lilypond-export/pull/17#discussion_r228915990).

What I think is the right thing is how package.ily goes along with choosing the "backend"/target.

I also think that FileExport in api.scm does the right thing.

What does *not* work is making the export-lilypond function from within Humdrum.scm (so far this only touches the Humdrum file) available to api.scm. I really don't understand it because in my MWE it *did* work. (see https://github.com/openlilylib/lilypond-export/pull/17#discussion_r229066643)