### PR TITLE
Add number attribute to lyric element

### DIFF
--- a/MusicXML.scm
+++ b/MusicXML.scm
@@ -157,10 +157,12 @@
            (writetuplet tuplet)
            (if (and (not chord) (list? lyrics))
                (for-each
-                (lambda (lyric)
-                  ;(ly:message "~A" lyric)
-                  (writeln "<lyric><syllabic>single</syllabic><text>~A</text></lyric>" lyric)
-                  ) lyrics))
+                (lambda (indexed-lyric)
+                  ;(ly:message "~A" indexed-lyric)
+                  (writeln "<lyric number=\"~A\"><syllabic>single</syllabic><text>~A</text></lyric>"
+                    (+ 1 (list-ref indexed-lyric 1))
+                    (list-ref indexed-lyric 0))
+                  ) (map list lyrics (iota (length lyrics)))))
 
            (writeln "</note>"))
 


### PR DESCRIPTION
Hello! I'm relatively new to Lilypond and Scheme, but I would love to see the MusicXML export development grow, specifically for the sake of dynamic web apps. This Pull Request is just me dipping my toes into development, and maybe I'll make more meaningful contributions in the future.

I love feedback, please be picky!

I'm not sure what was under development in the `lyric-stanza` branch, apologies if this is duplicating work or something.

## Problem:
Musescore 3 and https://wim.vree.org/js/abcweb.html both would only
render one syllable/line of lyrics even when two or more are specified 
in MusicXML import.

## Solution:
Here we add the number parameter to every lyric (counting up from "1").
This causes both lyric lines in export-example.xml to be read correctly
by both programs.