### PR TITLE
Fixed rendering order: dot before accidental, time-modification befor…

### DIFF
--- a/MusicXML.scm
+++ b/MusicXML.scm
@@ -148,12 +148,11 @@
 
            (writeln "<voice>~A</voice>" voice)
            (writetype dur)
+           (writedots (if (ly:duration? dur) (ly:duration-dot-count dur) 0))
            (if accidental
                (writeln "<accidental>~A</accidental>" (acctext accidental)))
-           (writedots (if (ly:duration? dur) (ly:duration-dot-count dur) 0))
-
-           (if (symbol? beam) (writeln "<beam number=\"1\">~A</beam>" beam))
            (writetimemod dur)
+           (if (symbol? beam) (writeln "<beam number=\"1\">~A</beam>" beam))
            (writetuplet tuplet)
            (if (and (not chord) (list? lyrics))
                (for-each


### PR DESCRIPTION
…e beam.  Tested loading xml file rendered by lilypond in MuseScore 3 and the change allowed the file to load without errors.